### PR TITLE
Allow longer timeout for GenServer call for find and find_one methods

### DIFF
--- a/lib/mongo/connection.ex
+++ b/lib/mongo/connection.ex
@@ -568,7 +568,7 @@ defmodule Mongo.Connection do
   end
 
   defp send_to_noreply({:ok, s}),
-    do: {:noreply, s}
+    do: {:noreply, s, get_timeout(s)}
   defp send_to_noreply({:error, reason, s}),
     do: {:disconnect, {:error, reason}, s}
 

--- a/lib/mongo/connection.ex
+++ b/lib/mongo/connection.ex
@@ -56,7 +56,7 @@ defmodule Mongo.Connection do
 
   @doc false
   def find(conn, coll, query, select, opts \\ []) do
-    GenServer.call(conn, {:find, coll, query, select, opts})
+    GenServer.call(conn, {:find, coll, query, select, opts}, get_timeout(opts))
   end
 
   @doc false
@@ -69,9 +69,12 @@ defmodule Mongo.Connection do
     GenServer.call(conn, {:kill_cursors, List.wrap(cursor_ids)})
   end
 
-  @doc false
+  @doc """
+  Executes a find query you can pass opts[:timeout]
+  when it's not set it will default to 5000 milliseconds
+  """
   def find_one(conn, coll, query, select, opts \\ []) do
-    GenServer.call(conn, {:find_one, coll, query, select, opts})
+    GenServer.call(conn, {:find_one, coll, query, select, opts}, get_timeout(opts))
   end
 
   @doc false
@@ -96,6 +99,10 @@ defmodule Mongo.Connection do
   @doc false
   def wire_version(conn) do
     GenServer.call(conn, :wire_version)
+  end
+
+  defp get_timeout(opts) do
+    opts[:timeout] || 5000
   end
 
   defp assign_ids(doc) when is_map(doc) do

--- a/mix.lock
+++ b/mix.lock
@@ -8,8 +8,10 @@
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "inch_ex": {:hex, :inch_ex, "0.4.0", "27829de2227edfba8fa5c431088578685c0956128b40522957077963e563e868", [:mix], [{:poison, "~> 1.2", [hex: :poison, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "mock": {:hex, :mock, "0.2.0", "5991877be6bb514b647dbd6f4869bc12bd7f2829df16e86c98d6108f966d34d7", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
   "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -409,4 +409,17 @@ defmodule Mongo.Test do
     assert %Mongo.Cursor{coll: "coll", opts: [no_cursor_timeout: true, skip: 10]} =
            Mongo.find(Pool, "coll", %{}, skip: 10, cursor_timeout: false)
   end
+
+
+  # If the computer is fast this test won't work
+  # we need a way to mock the GenServer call
+  #test "timeout find" do
+  #  coll = unique_name
+
+  #  1..1000 |> Enum.each(fn(num) ->
+  #    assert {:ok, _} = Mongo.insert_one(Pool, coll, %{foo: num})
+  #  end)
+
+  #  Mongo.find(Pool, coll, %{}, [timeout: 1]) |> Enum.to_list
+  #end
 end


### PR DESCRIPTION
I have worked to pass a timeout for the connection calls, this allows to make queries that last longer than **5 seconds**, I would like to make available a default timeout for socket connection `GenServer.call` and not need to pass the timeout

``` elixir
Mongo.find(Pool, coll, %{}, [timeout: 1]) |> Enum.to_list
```

like the sample in the code
